### PR TITLE
Don't replace text inside <code> elements

### DIFF
--- a/src/chrome/content/cloud-to-butt.js
+++ b/src/chrome/content/cloud-to-butt.js
@@ -22,7 +22,7 @@ function walk(node)
 			break;
 
 		case 3: // Text node
-            if(node.parentElement.tagName.toLowerCase() != "script") {
+            if(node.parentElement.tagName.toLowerCase() != "script" && node.parentElement.tagName.toLowerCase() != "code") {
                 handleText(node);
             }
 			break;


### PR DESCRIPTION
It's quite annoying when you copy/paste code or commands

[Example](https://packagecloud.io/):

``` bash
package_cloud push company/repo/ubuntu/precise pkg_1.0.deb
```
